### PR TITLE
Fix evm token transfer

### DIFF
--- a/factory/main.go
+++ b/factory/main.go
@@ -198,6 +198,7 @@ func (f *Factory) cfgEnrichAssetConfig(partialCfg *TokenAssetConfig) (*TokenAsse
 	if cfg.Chain != "" {
 		// token
 		cfg.Type = AssetTypeToken
+		cfg.AssetConfig.Type = AssetTypeToken
 		nativeAsset := cfg.Chain
 		cfg.NativeAsset = NativeAsset(nativeAsset)
 


### PR DESCRIPTION
evm/builder depends on `AssetConfig` for assets configuration, token type should be added to it.